### PR TITLE
Nodes as Maps [don't merge]

### DIFF
--- a/src/main/java/org/neo4j/jdbc/AbstractResultSet.java
+++ b/src/main/java/org/neo4j/jdbc/AbstractResultSet.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.neo4j.jdbc.util.Castable;
 
 /**
  * @author mh
@@ -370,12 +371,25 @@ public abstract class AbstractResultSet implements ResultSet
 
     public <T> T getObject( int columnIndex, Class<T> type ) throws SQLException
     {
-        return type.cast( getObject( columnIndex ) );
+        Object value = getObject(columnIndex);
+        if ( value == null )
+        {
+            return null;
+        }
+        if (type.isInstance( value ) )
+        {
+            return type.cast( value );
+        }
+        if ( value instanceof Castable )
+        {
+            return ( ( Castable ) value ).to( type );
+        }
+        throw new SQLException( "Unable to convert from " + value.getClass().getName() + " to " + type );
     }
 
     public <T> T getObject( String columnLabel, Class<T> type ) throws SQLException
     {
-        return type.cast( getObject( columnLabel ) );
+        return getObject( findColumn( columnLabel ), type );
     }
 
 

--- a/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -109,6 +109,13 @@ public class Neo4jStatement
     @Override
     public void cancel() throws SQLException
     {
+        if ( resultSet != null )
+        {
+            resultSet.close();
+        }
+        connection = null;
+        resultSet = null;
+        sqlWarning = null;
     }
 
     @Override

--- a/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -36,6 +36,7 @@ public class Neo4jStatement
     protected Neo4jConnection connection;
     protected ResultSet resultSet;
     protected SQLWarning sqlWarning;
+    private boolean closeOnCompletion;
 
     public Neo4jStatement( Neo4jConnection connection )
     {
@@ -180,6 +181,7 @@ public class Neo4jStatement
     @Override
     public boolean getMoreResults() throws SQLException
     {
+        if (resultSet!=null) resultSet.close();
         resultSet = null;
         return false;
     }
@@ -325,10 +327,11 @@ public class Neo4jStatement
 
     public void closeOnCompletion() throws SQLException
     {
+        this.closeOnCompletion = true;
     }
 
     public boolean isCloseOnCompletion() throws SQLException
     {
-        return false;
+        return closeOnCompletion;
     }
 }

--- a/src/main/java/org/neo4j/jdbc/embedded/Converter.java
+++ b/src/main/java/org/neo4j/jdbc/embedded/Converter.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.jdbc.embedded;
+
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.helpers.collection.IterableWrapper;
+import org.neo4j.helpers.collection.IteratorWrapper;
+import org.neo4j.jdbc.util.Castable;
+import org.neo4j.jdbc.util.PropertyContainerMap;
+
+import java.sql.SQLException;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+public class Converter
+{
+    public static Object convert( final Object value )
+    {
+        if ( value == null )
+        {
+            return null;
+        }
+        if ( value instanceof PropertyContainer )
+        {
+            return new PropertyContainerMap( (PropertyContainer) value );
+        }
+        if ( value instanceof Map )
+        {
+            return new GraphElementMap( (Map) value );
+        }
+        if ( value instanceof Iterable )
+        {
+            return new GraphIterable( value );
+        }
+        return value;
+    }
+
+    private static class GraphElementMap extends AbstractMap implements Castable
+    {
+        private final Map source;
+
+        public GraphElementMap( Map source )
+        {
+            this.source = source;
+        }
+
+        @Override
+        public Set<Entry> entrySet()
+        {
+            final Set<Entry> entries = source.entrySet();
+            return new AbstractSet<Entry>()
+            {
+                @Override
+                public Iterator<Entry> iterator()
+                {
+                    return new IteratorWrapper<Entry, Entry>( entries.iterator() )
+                    {
+                        @Override
+                        protected Entry underlyingObjectToObject( Entry entry )
+                        {
+                            return new SimpleEntry( entry.getKey(),
+                                    convert( entry.getValue() ) );
+                        }
+                    };
+                }
+
+                @Override
+                public int size()
+                {
+                    return 0;
+                }
+            };
+        }
+
+        @Override
+        public <T> T to( Class<T> type ) throws SQLException
+        {
+            if ( source == null )
+            {
+                return null;
+            }
+            if ( type.isInstance( source ) )
+            {
+                return type.cast( source );
+            }
+            throw new SQLException( "Unable to convert from " + source.getClass().getName() + " to " + type );
+        }
+    }
+
+    private static class GraphIterable extends IterableWrapper
+            implements Castable
+    {
+        private final Object source;
+
+        public GraphIterable( Object value )
+        {
+            super( (Iterable) value );
+            source = value;
+        }
+
+        @Override
+        protected Object underlyingObjectToObject( Object object )
+        {
+            return convert( object );
+        }
+
+        @Override
+        public <T> T to( Class<T> type ) throws SQLException
+        {
+            if ( source == null )
+            {
+                return null;
+            }
+            if ( type.isInstance( source ) )
+            {
+                return type.cast( source );
+            }
+            throw new SQLException( "Unable to convert from " + source.getClass().getName() + " to " + type );
+        }
+    }
+}

--- a/src/main/java/org/neo4j/jdbc/embedded/EmbeddedQueryExecutor.java
+++ b/src/main/java/org/neo4j/jdbc/embedded/EmbeddedQueryExecutor.java
@@ -1,19 +1,21 @@
 package org.neo4j.jdbc.embedded;
 
 import java.sql.SQLException;
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.cypher.javacompat.ExecutionEngine;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.*;
 import org.neo4j.helpers.Exceptions;
+import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.helpers.collection.IteratorWrapper;
 import org.neo4j.jdbc.ExecutionResult;
 import org.neo4j.jdbc.QueryExecutor;
 import org.neo4j.jdbc.Version;
+import org.neo4j.jdbc.util.PropertyContainerMap;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.KernelData;
 
@@ -80,7 +82,7 @@ public class EmbeddedQueryExecutor implements QueryExecutor
             {
                 for ( int i = 0; i < cols; i++ )
                 {
-                    resultRow[i] = row.get( columns.get( i ) );
+                    resultRow[i] = Converter.convert( row.get( columns.get( i ) ) );
                 }
                 return resultRow;
             }

--- a/src/main/java/org/neo4j/jdbc/util/Castable.java
+++ b/src/main/java/org/neo4j/jdbc/util/Castable.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.jdbc.util;
+
+import java.sql.SQLException;
+
+public interface Castable
+{
+    <T> T to( Class<T> type ) throws SQLException;
+}

--- a/src/main/java/org/neo4j/jdbc/util/PropertyContainerMap.java
+++ b/src/main/java/org/neo4j/jdbc/util/PropertyContainerMap.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.jdbc.util;
+
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.helpers.collection.IteratorUtil;
+
+import java.sql.SQLException;
+import java.util.*;
+
+public class PropertyContainerMap extends AbstractMap<String, Object> implements Castable
+{
+    private final PropertyContainer source;
+
+    public PropertyContainerMap( PropertyContainer source )
+    {
+        this.source = source;
+    }
+
+    @Override
+    public <T> T to( Class<T> type ) throws SQLException
+    {
+        if ( source == null )
+        {
+            return null;
+        }
+        if ( type.isInstance( source ) )
+        {
+            return type.cast( source );
+        }
+        throw new SQLException( "Unable to convert from " + source.getClass().getName() + " to " + type );
+    }
+
+
+    @Override
+    public String toString()
+    {
+        return source.toString();
+    }
+
+
+    @Override
+    public Set<Entry<String, Object>> entrySet()
+    {
+        return new AbstractSet<Entry<String, Object>>()
+        {
+            @Override
+            public Iterator<Entry<String, Object>> iterator()
+            {
+                return new PropertyIterator( source );
+            }
+
+            @Override
+            public int size()
+            {
+                return IteratorUtil.count( source.getPropertyKeys() );
+            }
+        };
+    }
+
+    private static class PropertyIterator implements Iterator<Entry<String, Object>>
+    {
+
+        private final PropertyContainer source;
+        private final Iterator<String> keys;
+
+        public PropertyIterator( PropertyContainer source )
+        {
+            this.source = source;
+            this.keys = source.getPropertyKeys().iterator();
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return keys.hasNext();
+        }
+
+        @Override
+        public Entry<String, Object> next()
+        {
+            final String key = keys.next();
+            return new Entry<String, Object>()
+            {
+                @Override
+                public String getKey()
+                {
+                    return key;
+                }
+
+                @Override
+                public Object getValue()
+                {
+                    return source.getProperty( key );
+                }
+
+                @Override
+                public Object setValue( Object value )
+                {
+                    Object old = source.getProperty( key, null );
+                    source.setProperty( key, value );
+                    return old;
+                }
+            };
+        }
+
+        @Override
+        public void remove()
+        {
+            keys.remove();
+        }
+    }
+}

--- a/src/test/java/org/neo4j/jdbc/Neo4jJdbcTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jJdbcTest.java
@@ -80,9 +80,9 @@ public abstract class Neo4jJdbcTest
     @Parameterized.Parameters
     public static Collection<Object[]> data()
     {
-//        return Arrays.<Object[]>asList(new Object[]{Mode.embedded},new Object[]{Mode.server},
-// new Object[]{Mode.server_auth},new Object[]{Mode.server_tx});
-        return Arrays.<Object[]>asList( new Object[]{Mode.server_tx} );
+        return Arrays.<Object[]>asList(new Object[]{Mode.embedded},new Object[]{Mode.server},
+                                       new Object[]{Mode.server_auth},new Object[]{Mode.server_tx});
+//        return Arrays.<Object[]>asList( new Object[]{Mode.server_tx} );
 //        return Arrays.<Object[]>asList(new Object[]{Mode.embedded});
     }
 

--- a/src/test/java/org/neo4j/jdbc/Neo4jQueryNodeTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jQueryNodeTest.java
@@ -24,20 +24,31 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.jdbc.util.Castable;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class Neo4jQueryNodeTest extends Neo4jJdbcTest
 {
+
+    private static final DynamicRelationshipType REL = DynamicRelationshipType.withName( "REL" );
+    private static final Label LABEL = DynamicLabel.label( "Label" );
 
     public Neo4jQueryNodeTest( Mode mode ) throws SQLException
     {
@@ -60,39 +71,52 @@ public class Neo4jQueryNodeTest extends Neo4jJdbcTest
     {
         createData( gdb );
         Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery( "cypher 1.9 start n=node(*) match p=(n)-[r?]-(m) return n,r,m,p,ID(n)," +
-                "length(p),n.name? as name limit 5" );
+        ResultSet rs = stmt.executeQuery( "match (n:Label) optional match p=(n)-[r]->(m) return n,r,m,p,ID(n)," +
+                "length(p),n.node as name order by id(n) asc limit 5" );
         int count = 0;
         ResultSetMetaData metaData = rs.getMetaData();
         int cols = metaData.getColumnCount();
-        Assert.assertThat( cols, is( 7 ) );
-        while ( rs.next() )
+        assertThat( cols, is( 7 ) );
         {
-            for ( int i = 1; i <= cols; i++ )
+            while ( rs.next() )
             {
-                //String columnName = metaData.getColumnName(i);
-                //System.out.println(columnName);
-                System.out.print( rs.getObject( i ) + "\t" );
+                Object node = rs.getObject( "n" );
+                assertTrue( node instanceof Map );
+                    if ( mode == Mode.embedded )
+                    {
+                        try (Transaction tx = gdb.beginTx())
+                        {
+                            assertTrue( node instanceof Castable );
+                            assertEquals( "node" + count, ( (Castable) node ).to( Node.class ).getProperty( "node" ) );
+                            assertEquals( "node" + count, rs.getObject( "n", Node.class ).getProperty( "node" ) );
+                            tx.success();
+                        }
+                    }
+                    for ( int i = 1; i <= cols; i++ )
+                    {
+                        //String columnName = metaData.getColumnName(i);
+                        //System.out.println(columnName);
+                        System.out.print( rs.getObject( i ) + "\t" );
+                    }
+                    System.out.println();
+                count++;
             }
-            System.out.println();
-            count++;
         }
 
-        Assert.assertThat( count, is( 5 ) );
+        assertThat( count, is( 5 ) );
     }
 
     private void createData( GraphDatabaseService gdb )
     {
         try ( Transaction tx = gdb.beginTx() )
         {
-            final Node n1 = gdb.createNode();
-            n1.setProperty( "name", "n1" );
-            final Node n2 = gdb.createNode();
-            final Node n3 = gdb.createNode();
-            final Node n4 = gdb.createNode();
-            final Node n5 = gdb.createNode();
-            final Relationship rel1 = n1.createRelationshipTo( n2, DynamicRelationshipType.withName( "REL" ) );
-            rel1.setProperty( "name", "rel1" );
+            Node prev = null;
+            for (int i=0;i<5;i++) {
+                Node node = gdb.createNode( LABEL );
+                node.setProperty( "node", "node"+i );
+                if (prev != null) prev.createRelationshipTo( node, REL ).setProperty( "rel","rel"+i );
+                prev = node;
+            }
             tx.success();
         }
     }


### PR DESCRIPTION
Attempt to render nodes and relationships as 'Castable' maps that
you then can cast to node or rel objects.

Doesn't work yet because of read transactions needed while reading
the lazy result set.

Potential solutions:
1. Require transactions around the whole query + resultset operation
2. Eagerly read the full resultset and convert everything to a real map
3. Start new read-tx for every access to a potential node or rel-object
4. Something better than the 3 above
