### PR TITLE
support for configurable User-Agent http header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
 
             <!--
                   <plugin>

--- a/src/main/java/org/neo4j/jdbc/util/UserAgentBuilder.java
+++ b/src/main/java/org/neo4j/jdbc/util/UserAgentBuilder.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.jdbc.util;
+
+import java.util.Properties;
+
+public class UserAgentBuilder
+{
+    public static final String USER_AGENT = "userAgent";
+    private final Properties jdbcDriverProperties;
+
+    public UserAgentBuilder( Properties jdbcDriverProperties )
+    {
+        this.jdbcDriverProperties = jdbcDriverProperties;
+    }
+
+    public String getAgent()
+    {
+        StringBuilder sb = new StringBuilder();
+        if ( jdbcDriverProperties.containsKey( USER_AGENT ) )
+        {
+            sb.append( jdbcDriverProperties.getProperty( USER_AGENT ) ).append( " via " );
+        }
+        sb.append( getImplementationTitle() );
+        sb.append( "/" );
+        sb.append( getImplementationVersion() );
+        return sb.toString();
+    }
+
+    private String getImplementationVersion()
+    {
+        String implementationVersion = getClass().getPackage().getImplementationVersion();
+        if ( implementationVersion == null )
+        {
+            implementationVersion = "<unversioned>";
+        }
+        return implementationVersion;
+    }
+
+    private String getImplementationTitle()
+    {
+        String implementationTitle = getClass().getPackage().getImplementationTitle();
+        if ( implementationTitle == null )
+        {
+            implementationTitle = "Neo4j JDBC Driver";
+        }
+        return implementationTitle;
+    }
+}

--- a/src/test/java/org/neo4j/jdbc/rest/DiscoveryResourceTest.java
+++ b/src/test/java/org/neo4j/jdbc/rest/DiscoveryResourceTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 public class DiscoveryResourceTest
 {
     public static final String URI = "http://localhost:" + TestServer.PORT;
+    public static final String USER_AGENT = "Neo4j JDBC Driver/<unversioned>";
     private static WebServer webServer;
     private static GraphDatabaseAPI db;
     private static Resources.DiscoveryClientResource resource;
@@ -40,7 +41,7 @@ public class DiscoveryResourceTest
             tx.success();
         }
         webServer = TestServer.startWebServer( db, TestServer.PORT, false );
-        resource = new Resources(URI, new Client("HTTP")).getDiscoveryResource(  );
+        resource = new Resources(URI, new Client("HTTP"), USER_AGENT ).getDiscoveryResource(  );
     }
 
     @AfterClass
@@ -85,5 +86,11 @@ public class DiscoveryResourceTest
     public void testGetRelationshipTypes() throws Exception
     {
         assertEquals( asList( "FOO_BAR" ), resource.getRelationshipTypes() );
+    }
+
+    @Test
+    public void testUserAgent()
+    {
+        assertEquals( USER_AGENT, resource.getClientInfo().getAgent() );
     }
 }

--- a/src/test/java/org/neo4j/jdbc/util/UserAgentBuilderTest.java
+++ b/src/test/java/org/neo4j/jdbc/util/UserAgentBuilderTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.jdbc.util;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UserAgentBuilderTest
+{
+
+    @Test
+    public void testGetAgentEmptyProperties() throws Exception
+    {
+        Properties props = new Properties(  );
+        assertEquals( "Neo4j JDBC Driver/<unversioned>", new UserAgentBuilder( props ).getAgent());
+    }
+
+    @Test
+    public void testGetAgentWithProperties() throws Exception
+    {
+        Properties props = new Properties(  );
+        props.put("userAgent", "mytool");
+        assertEquals( "mytool via Neo4j JDBC Driver/<unversioned>", new UserAgentBuilder( props ).getAgent());
+    }
+
+}


### PR DESCRIPTION
Instead of the "Restlet/<version>" as value for User-Agent http header, the jdbc drivers uses as default "<title>/<version>". title and version are loaded from MANIFEST.MF which is populated by pom.xml's <name> and <version> tag.
Optionally a JDBC property "userAgent" can used. If so, the resulting User-Agent string is "<jdbcprop> via <title>/>version>", e.g. "Grails Driver 2.0.0-M02 via Neo4j JDBC Driver/2.0.3-SNAPSHOT".
