### PR TITLE
changed project version to 2.2-SNAPSHOT from 2.1.5-SNAPSHOT to reflect t...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-jdbc</artifactId>
-    <version>2.1.5-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <name>Neo4j JDBC Driver</name>
     <description>Neo4j JDBC Driver</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
     <properties>
-        <neo4j.version>2.1.5</neo4j.version>
+        <neo4j.version>2.2-SNAPSHOT</neo4j.version>
         <bundle.namespace>org.neo4j.jdbc</bundle.namespace>
         <short-name>neo4j-jdbc</short-name>
         <license-text.header>GPL-3-header.txt</license-text.header>
@@ -62,6 +62,11 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+        </dependency>
         <dependency>
             <groupId>org.restlet.jse</groupId>
             <artifactId>org.restlet</artifactId>

--- a/src/test/java/org/neo4j/jdbc/DatabasesTest.java
+++ b/src/test/java/org/neo4j/jdbc/DatabasesTest.java
@@ -3,6 +3,7 @@ package org.neo4j.jdbc;
 import java.io.File;
 import java.util.Properties;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -12,7 +13,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.jdbc.embedded.EmbeddedDatabases;
 import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.kernel.EmbeddedReadOnlyGraphDatabase;
-import org.neo4j.kernel.impl.util.FileUtils;
 import org.neo4j.test.ImpermanentGraphDatabase;
 
 import static org.junit.Assert.assertSame;
@@ -61,7 +61,7 @@ public class DatabasesTest
     @Test
     public void testLocateFileDb() throws Exception
     {
-        FileUtils.deleteRecursively( new File( "target/test-db" ) );
+        FileUtils.deleteDirectory( new File( "target/test-db" ) );
         final GraphDatabaseService db = databases.createDatabase( ":file:target/test-db", null );
         assertTrue( db instanceof EmbeddedGraphDatabase );
         final GraphDatabaseService db2 = databases.createDatabase( ":file:target/test-db", null );
@@ -72,7 +72,7 @@ public class DatabasesTest
     @Ignore("Not possible anymore to have a rw and ro-db accesssing the same store-files")
     public void testLocateFileDbReadonly() throws Exception
     {
-        FileUtils.deleteRecursively( new File( "target/test-db-ro" ) );
+        FileUtils.deleteDirectory( new File( "target/test-db-ro" ) );
         GraphDatabaseService db0 = new GraphDatabaseFactory().newEmbeddedDatabase( "target/test-db-ro" );
         try
         {


### PR DESCRIPTION
...he Neo4j version it is using

updated Neo4j version from 2.1.5 to 2.2-SNAPSHOT
added apache commons-io dependency to account for org.neo4j.kernel.impl.util.FileUtils no longer being a public API
COMPILES BUT DOES NOT PASS TESTS (needs work to be 2.2 compatible)
