### PR TITLE
Throw UnsupportedOperationException from unimplemented Neo4jStatement methods

### DIFF
--- a/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -212,7 +212,7 @@ public class Neo4jStatement
     @Override
     public int getResultSetConcurrency() throws SQLException
     {
-        throw unsupported( "getResultSetConcurrency" );
+        return ResultSet.CONCUR_READ_ONLY;
     }
 
     @Override

--- a/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -23,6 +23,7 @@ package org.neo4j.jdbc;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.Collections;
@@ -339,8 +340,8 @@ public class Neo4jStatement
         return false;
     }
 
-    private static UnsupportedOperationException unsupported( String methodName )
+    private static SQLFeatureNotSupportedException unsupported( String methodName )
     {
-        return new UnsupportedOperationException( methodName + " is not supported by Neo4jStatement." );
+        return new SQLFeatureNotSupportedException( methodName + " is not supported by Neo4jStatement." );
     }
 }

--- a/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -53,6 +53,7 @@ public class Neo4jStatement
     public int executeUpdate( String s ) throws SQLException
     {
         execute( s );
+        // TODO return actual update count
         return 0;
     }
 
@@ -173,6 +174,7 @@ public class Neo4jStatement
     @Override
     public int getUpdateCount() throws SQLException
     {
+        // TODO return actual update count
         throw unsupported( "getUpdateCount" );
     }
 

--- a/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -194,7 +194,7 @@ public class Neo4jStatement
     @Override
     public int getFetchDirection() throws SQLException
     {
-        throw unsupported( "getFetchDirection" );
+        return ResultSet.FETCH_UNKNOWN;
     }
 
     @Override

--- a/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
+++ b/src/main/java/org/neo4j/jdbc/Neo4jStatement.java
@@ -71,44 +71,49 @@ public class Neo4jStatement
     @Override
     public int getMaxFieldSize() throws SQLException
     {
-        return 0;
+        throw unsupported( "getMaxFieldSize" );
     }
 
     @Override
     public void setMaxFieldSize( int i ) throws SQLException
     {
+        throw unsupported( "setMaxFieldSize " );
     }
 
     @Override
     public int getMaxRows() throws SQLException
     {
-        return 0;
+        throw unsupported( "getMaxRows" );
     }
 
     @Override
     public void setMaxRows( int i ) throws SQLException
     {
+        throw unsupported( "setMaxRows" );
     }
 
     @Override
     public void setEscapeProcessing( boolean b ) throws SQLException
     {
+        throw unsupported( "setEscapeProcessing" );
     }
 
     @Override
     public int getQueryTimeout() throws SQLException
     {
-        return 0;
+        throw unsupported( "getQueryTimeout" );
     }
 
     @Override
     public void setQueryTimeout( int i ) throws SQLException
     {
+        throw unsupported( "setQueryTimeout" );
     }
 
     @Override
     public void cancel() throws SQLException
     {
+        throw unsupported( "cancel" );
     }
 
     @Override
@@ -126,6 +131,7 @@ public class Neo4jStatement
     @Override
     public void setCursorName( String s ) throws SQLException
     {
+        throw unsupported( "setCursorName" );
     }
 
     @Override
@@ -167,7 +173,7 @@ public class Neo4jStatement
     @Override
     public int getUpdateCount() throws SQLException
     {
-        return -1;
+        throw unsupported( "getUpdateCount" );
     }
 
     @Override
@@ -180,29 +186,31 @@ public class Neo4jStatement
     @Override
     public void setFetchDirection( int i ) throws SQLException
     {
+        throw unsupported( "setFetchDirection" );
     }
 
     @Override
     public int getFetchDirection() throws SQLException
     {
-        return 0;
+        throw unsupported( "getFetchDirection" );
     }
 
     @Override
     public void setFetchSize( int i ) throws SQLException
     {
+        throw unsupported( "setFetchSize" );
     }
 
     @Override
     public int getFetchSize() throws SQLException
     {
-        return 0;
+        throw unsupported( "getFetchSize" );
     }
 
     @Override
     public int getResultSetConcurrency() throws SQLException
     {
-        return 0;
+        throw unsupported( "getResultSetConcurrency" );
     }
 
     @Override
@@ -214,17 +222,19 @@ public class Neo4jStatement
     @Override
     public void addBatch( String s ) throws SQLException
     {
+        throw unsupported( "addBatch" );
     }
 
     @Override
     public void clearBatch() throws SQLException
     {
+        throw unsupported( "clearBatch" );
     }
 
     @Override
     public int[] executeBatch() throws SQLException
     {
-        return new int[0];
+        throw unsupported( "executeBatch" );
     }
 
     @Override
@@ -296,6 +306,7 @@ public class Neo4jStatement
     @Override
     public void setPoolable( boolean b ) throws SQLException
     {
+        throw unsupported( "setPoolable" );
     }
 
     @Override
@@ -318,10 +329,16 @@ public class Neo4jStatement
 
     public void closeOnCompletion() throws SQLException
     {
+        throw unsupported( "closeOnCompletion" );
     }
 
     public boolean isCloseOnCompletion() throws SQLException
     {
         return false;
+    }
+
+    private static UnsupportedOperationException unsupported( String methodName )
+    {
+        return new UnsupportedOperationException( methodName + " is not supported by Neo4jStatement." );
     }
 }

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -67,14 +68,14 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         assertEquals( nodeId, ((Number) rs.getObject( "id" )).intValue() );
         assertEquals( nodeId, rs.getLong( "id" ) );
         assertEquals( nodeId, ((Number) rs.getObject( 1 )).intValue() );
-        assertEquals( nodeId, rs.getLong( 1 ) );
+        assertEquals(nodeId, rs.getLong(1));
         assertFalse( rs.next() );
     }
 
     @Test(expected = SQLException.class)
     public void testPreparedStatementMissingParameter() throws Exception
     {
-        final PreparedStatement ps = conn.prepareStatement( "start n=node({1}) return ID(n) as id" );
+        final PreparedStatement ps = conn.prepareStatement("start n=node({1}) return ID(n) as id");
         final ResultSet rs = ps.executeQuery();
         rs.next();
     }
@@ -90,14 +91,14 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         assertEquals( nodeId, rs.getLong( "id" ) );
         assertEquals( nodeId, ((Number) rs.getObject( 1 )).intValue() );
         assertEquals( nodeId, rs.getLong( 1 ) );
-        assertFalse( rs.next() );
+        assertFalse(rs.next());
     }
 
     @Test
     public void testCreateNodeStatement() throws Exception
     {
         final PreparedStatement ps = conn.prepareStatement( "create (n:User {name:{1}})" );
-        ps.setString( 1, "test" );
+        ps.setString(1, "test");
         // TODO int count = ps.executeUpdate();
         int count = 0;
         ps.executeUpdate();
@@ -108,14 +109,14 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
             count++;
         }
         done();
-        assertEquals( 1, count );
+        assertEquals(1, count);
     }
 
     @Test
     public void testCreateNodeStatementWithMapParam() throws Exception
     {
         final PreparedStatement ps = conn.prepareStatement( "create (n:User {1})" );
-        ps.setObject( 1, map( "name", "test" ) );
+        ps.setObject(1, map("name", "test"));
         // TODO int count = ps.executeUpdate();
         int count = 0;
         ps.executeUpdate();
@@ -132,8 +133,8 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
     @Test(expected = SQLException.class)
     public void testCreateOnReadonlyConnection() throws Exception
     {
-        conn.setReadOnly( true );
-        conn.createStatement().executeUpdate( "create (n {name:{1}})" );
+        conn.setReadOnly(true);
+        conn.createStatement().executeUpdate("create (n {name:{1}})");
     }
 
     @Test(expected = SQLDataException.class)
@@ -141,8 +142,8 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
     {
         final ResultSet rs = conn.createStatement().executeQuery( nodeByIdQuery( nodeId ) );
         assertTrue( rs.next() );
-        assertEquals( nodeId, rs.getObject( 0 ) );
-        assertFalse( rs.next() );
+        assertEquals(nodeId, rs.getObject(0));
+        assertFalse(rs.next());
     }
 
     @Test(expected = SQLDataException.class)
@@ -150,7 +151,7 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
     {
         final ResultSet rs = conn.createStatement().executeQuery( nodeByIdQuery( nodeId ) );
         rs.next();
-        rs.getObject( 2 );
+        rs.getObject(2);
     }
 
     @Test(expected = SQLException.class)
@@ -160,4 +161,125 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         rs.next();
         rs.getObject( "foo" );
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetMaxFieldSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().getMaxFieldSize();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetMaxFieldSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().setMaxFieldSize(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetMaxRowsIsUnsupported() throws Exception
+    {
+        conn.createStatement().getMaxRows();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetMaxRowsIsUnsupported() throws Exception
+    {
+        conn.createStatement().setMaxRows(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetEscapeProcessingIsUnsupported() throws Exception
+    {
+        conn.createStatement().setEscapeProcessing(false);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetQueryTimeoutIsUnsupported() throws Exception
+    {
+        conn.createStatement().getQueryTimeout();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetQueryTimeoutIsUnsupported() throws Exception
+    {
+        conn.createStatement().setQueryTimeout(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCancelIsUnsupported() throws Exception
+    {
+        conn.createStatement().cancel();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetCursorNameIsUnsupported() throws Exception
+    {
+        conn.createStatement().setCursorName("shouldNotWork");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetUpdateCountIsUnsupported() throws Exception
+    {
+        conn.createStatement().getUpdateCount();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetFetchDirectionIsUnsupported() throws Exception
+    {
+        conn.createStatement().setFetchDirection(ResultSet.FETCH_FORWARD);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetFetchDirectionIsUnsupported() throws Exception
+    {
+        conn.createStatement().getFetchDirection();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetFetchSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().setFetchSize(50);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetFetchSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().getFetchSize();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetResultSetConcurrencyIsUnsupported() throws Exception
+    {
+        conn.createStatement().getResultSetConcurrency();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAddBatchIsUnsupported() throws Exception
+    {
+        conn.createStatement().addBatch("Doesn't work'");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testClearBatchIsUnsupported() throws Exception
+    {
+        conn.createStatement().clearBatch();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testExecuteBatchIsUnsupported() throws Exception
+    {
+        conn.createStatement().executeBatch();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetPoolableIsUnsupported() throws Exception
+    {
+        conn.createStatement().setPoolable( false );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCloseOnCompletionIsUnsupported() throws Exception
+    {
+        conn.createStatement().closeOnCompletion();
+    }
+
 }

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
@@ -160,4 +160,9 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         rs.next();
         rs.getObject( "foo" );
     }
+
+    @Test
+    public void testGetFetchDirectionIsUnknown() throws Exception {
+        assertEquals(ResultSet.FETCH_UNKNOWN, conn.createStatement().getFetchDirection());
+    }
 }

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
@@ -24,7 +24,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -68,14 +67,14 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         assertEquals( nodeId, ((Number) rs.getObject( "id" )).intValue() );
         assertEquals( nodeId, rs.getLong( "id" ) );
         assertEquals( nodeId, ((Number) rs.getObject( 1 )).intValue() );
-        assertEquals(nodeId, rs.getLong(1));
+        assertEquals( nodeId, rs.getLong( 1 ) );
         assertFalse( rs.next() );
     }
 
     @Test(expected = SQLException.class)
     public void testPreparedStatementMissingParameter() throws Exception
     {
-        final PreparedStatement ps = conn.prepareStatement("start n=node({1}) return ID(n) as id");
+        final PreparedStatement ps = conn.prepareStatement( "start n=node({1}) return ID(n) as id" );
         final ResultSet rs = ps.executeQuery();
         rs.next();
     }
@@ -91,14 +90,14 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         assertEquals( nodeId, rs.getLong( "id" ) );
         assertEquals( nodeId, ((Number) rs.getObject( 1 )).intValue() );
         assertEquals( nodeId, rs.getLong( 1 ) );
-        assertFalse(rs.next());
+        assertFalse( rs.next() );
     }
 
     @Test
     public void testCreateNodeStatement() throws Exception
     {
         final PreparedStatement ps = conn.prepareStatement( "create (n:User {name:{1}})" );
-        ps.setString(1, "test");
+        ps.setString( 1, "test" );
         // TODO int count = ps.executeUpdate();
         int count = 0;
         ps.executeUpdate();
@@ -109,14 +108,14 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
             count++;
         }
         done();
-        assertEquals(1, count);
+        assertEquals( 1, count );
     }
 
     @Test
     public void testCreateNodeStatementWithMapParam() throws Exception
     {
         final PreparedStatement ps = conn.prepareStatement( "create (n:User {1})" );
-        ps.setObject(1, map("name", "test"));
+        ps.setObject( 1, map( "name", "test" ) );
         // TODO int count = ps.executeUpdate();
         int count = 0;
         ps.executeUpdate();
@@ -133,8 +132,8 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
     @Test(expected = SQLException.class)
     public void testCreateOnReadonlyConnection() throws Exception
     {
-        conn.setReadOnly(true);
-        conn.createStatement().executeUpdate("create (n {name:{1}})");
+        conn.setReadOnly( true );
+        conn.createStatement().executeUpdate( "create (n {name:{1}})" );
     }
 
     @Test(expected = SQLDataException.class)
@@ -142,8 +141,8 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
     {
         final ResultSet rs = conn.createStatement().executeQuery( nodeByIdQuery( nodeId ) );
         assertTrue( rs.next() );
-        assertEquals(nodeId, rs.getObject(0));
-        assertFalse(rs.next());
+        assertEquals( nodeId, rs.getObject( 0 ) );
+        assertFalse( rs.next() );
     }
 
     @Test(expected = SQLDataException.class)
@@ -151,7 +150,7 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
     {
         final ResultSet rs = conn.createStatement().executeQuery( nodeByIdQuery( nodeId ) );
         rs.next();
-        rs.getObject(2);
+        rs.getObject( 2 );
     }
 
     @Test(expected = SQLException.class)
@@ -161,125 +160,4 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
         rs.next();
         rs.getObject( "foo" );
     }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetMaxFieldSizeIsUnsupported() throws Exception
-    {
-        conn.createStatement().getMaxFieldSize();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetMaxFieldSizeIsUnsupported() throws Exception
-    {
-        conn.createStatement().setMaxFieldSize(1);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetMaxRowsIsUnsupported() throws Exception
-    {
-        conn.createStatement().getMaxRows();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetMaxRowsIsUnsupported() throws Exception
-    {
-        conn.createStatement().setMaxRows(1);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetEscapeProcessingIsUnsupported() throws Exception
-    {
-        conn.createStatement().setEscapeProcessing(false);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetQueryTimeoutIsUnsupported() throws Exception
-    {
-        conn.createStatement().getQueryTimeout();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetQueryTimeoutIsUnsupported() throws Exception
-    {
-        conn.createStatement().setQueryTimeout(0);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testCancelIsUnsupported() throws Exception
-    {
-        conn.createStatement().cancel();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetCursorNameIsUnsupported() throws Exception
-    {
-        conn.createStatement().setCursorName("shouldNotWork");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetUpdateCountIsUnsupported() throws Exception
-    {
-        conn.createStatement().getUpdateCount();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetFetchDirectionIsUnsupported() throws Exception
-    {
-        conn.createStatement().setFetchDirection(ResultSet.FETCH_FORWARD);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetFetchDirectionIsUnsupported() throws Exception
-    {
-        conn.createStatement().getFetchDirection();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetFetchSizeIsUnsupported() throws Exception
-    {
-        conn.createStatement().setFetchSize(50);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetFetchSizeIsUnsupported() throws Exception
-    {
-        conn.createStatement().getFetchSize();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetResultSetConcurrencyIsUnsupported() throws Exception
-    {
-        conn.createStatement().getResultSetConcurrency();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAddBatchIsUnsupported() throws Exception
-    {
-        conn.createStatement().addBatch("Doesn't work'");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testClearBatchIsUnsupported() throws Exception
-    {
-        conn.createStatement().clearBatch();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testExecuteBatchIsUnsupported() throws Exception
-    {
-        conn.createStatement().executeBatch();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetPoolableIsUnsupported() throws Exception
-    {
-        conn.createStatement().setPoolable( false );
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testCloseOnCompletionIsUnsupported() throws Exception
-    {
-        conn.createStatement().closeOnCompletion();
-    }
-
 }

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementTest.java
@@ -165,4 +165,9 @@ public class Neo4jStatementTest extends Neo4jJdbcTest
     public void testGetFetchDirectionIsUnknown() throws Exception {
         assertEquals(ResultSet.FETCH_UNKNOWN, conn.createStatement().getFetchDirection());
     }
+
+    @Test
+    public void testGetResultSetConcurrencyIsReadOnly() throws Exception {
+        assertEquals(ResultSet.CONCUR_READ_ONLY, conn.createStatement().getResultSetConcurrency());
+    }
 }

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+public class Neo4jStatementUnsupportedOperationsTest extends Neo4jJdbcTest
+{
+
+    public Neo4jStatementUnsupportedOperationsTest( Mode mode ) throws SQLException
+    {
+        super( mode );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetMaxFieldSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().getMaxFieldSize();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetMaxFieldSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().setMaxFieldSize( 1 );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetMaxRowsIsUnsupported() throws Exception
+    {
+        conn.createStatement().getMaxRows();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetMaxRowsIsUnsupported() throws Exception
+    {
+        conn.createStatement().setMaxRows( 1 );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetEscapeProcessingIsUnsupported() throws Exception
+    {
+        conn.createStatement().setEscapeProcessing( false );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetQueryTimeoutIsUnsupported() throws Exception
+    {
+        conn.createStatement().getQueryTimeout();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetQueryTimeoutIsUnsupported() throws Exception
+    {
+        conn.createStatement().setQueryTimeout( 0 );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCancelIsUnsupported() throws Exception
+    {
+        conn.createStatement().cancel();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetCursorNameIsUnsupported() throws Exception
+    {
+        conn.createStatement().setCursorName( "shouldNotWork" );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetUpdateCountIsUnsupported() throws Exception
+    {
+        conn.createStatement().getUpdateCount();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetFetchDirectionIsUnsupported() throws Exception
+    {
+        conn.createStatement().setFetchDirection(ResultSet.FETCH_FORWARD);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetFetchDirectionIsUnsupported() throws Exception
+    {
+        conn.createStatement().getFetchDirection();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetFetchSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().setFetchSize( 50 );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetFetchSizeIsUnsupported() throws Exception
+    {
+        conn.createStatement().getFetchSize();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetResultSetConcurrencyIsUnsupported() throws Exception
+    {
+        conn.createStatement().getResultSetConcurrency();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAddBatchIsUnsupported() throws Exception
+    {
+        conn.createStatement().addBatch( "Does not work" );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testClearBatchIsUnsupported() throws Exception
+    {
+        conn.createStatement().clearBatch();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testExecuteBatchIsUnsupported() throws Exception
+    {
+        conn.createStatement().executeBatch();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetPoolableIsUnsupported() throws Exception
+    {
+        conn.createStatement().setPoolable( false );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCloseOnCompletionIsUnsupported() throws Exception
+    {
+        conn.createStatement().closeOnCompletion();
+    }
+
+}

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
@@ -112,12 +112,6 @@ public class Neo4jStatementUnsupportedOperationsTest extends Neo4jJdbcTest
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testGetResultSetConcurrencyIsUnsupported() throws Exception
-    {
-        conn.createStatement().getResultSetConcurrency();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
     public void testAddBatchIsUnsupported() throws Exception
     {
         conn.createStatement().addBatch( "Does not work" );

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
@@ -22,6 +22,7 @@ package org.neo4j.jdbc;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 
 import org.junit.Test;
 
@@ -33,109 +34,109 @@ public class Neo4jStatementUnsupportedOperationsTest extends Neo4jJdbcTest
         super( mode );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testGetMaxFieldSizeIsUnsupported() throws Exception
     {
         conn.createStatement().getMaxFieldSize();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetMaxFieldSizeIsUnsupported() throws Exception
     {
         conn.createStatement().setMaxFieldSize( 1 );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testGetMaxRowsIsUnsupported() throws Exception
     {
         conn.createStatement().getMaxRows();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetMaxRowsIsUnsupported() throws Exception
     {
         conn.createStatement().setMaxRows( 1 );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetEscapeProcessingIsUnsupported() throws Exception
     {
         conn.createStatement().setEscapeProcessing( false );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testGetQueryTimeoutIsUnsupported() throws Exception
     {
         conn.createStatement().getQueryTimeout();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetQueryTimeoutIsUnsupported() throws Exception
     {
         conn.createStatement().setQueryTimeout( 0 );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testCancelIsUnsupported() throws Exception
     {
         conn.createStatement().cancel();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetCursorNameIsUnsupported() throws Exception
     {
         conn.createStatement().setCursorName( "shouldNotWork" );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testGetUpdateCountIsUnsupported() throws Exception
     {
         conn.createStatement().getUpdateCount();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetFetchDirectionIsUnsupported() throws Exception
     {
         conn.createStatement().setFetchDirection(ResultSet.FETCH_FORWARD);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetFetchSizeIsUnsupported() throws Exception
     {
         conn.createStatement().setFetchSize( 50 );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testGetFetchSizeIsUnsupported() throws Exception
     {
         conn.createStatement().getFetchSize();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testAddBatchIsUnsupported() throws Exception
     {
         conn.createStatement().addBatch( "Does not work" );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testClearBatchIsUnsupported() throws Exception
     {
         conn.createStatement().clearBatch();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testExecuteBatchIsUnsupported() throws Exception
     {
         conn.createStatement().executeBatch();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testSetPoolableIsUnsupported() throws Exception
     {
         conn.createStatement().setPoolable( false );
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void testCloseOnCompletionIsUnsupported() throws Exception
     {
         conn.createStatement().closeOnCompletion();

--- a/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
+++ b/src/test/java/org/neo4j/jdbc/Neo4jStatementUnsupportedOperationsTest.java
@@ -100,12 +100,6 @@ public class Neo4jStatementUnsupportedOperationsTest extends Neo4jJdbcTest
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testGetFetchDirectionIsUnsupported() throws Exception
-    {
-        conn.createStatement().getFetchDirection();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
     public void testSetFetchSizeIsUnsupported() throws Exception
     {
         conn.createStatement().setFetchSize( 50 );


### PR DESCRIPTION
Fix for #17. Neo4jStatement should not fail silently when methods are called which are currently not supported.

I've added code that throws UOE from every method where it was obvious to me. There some methods I'm not sure about:
- execute(String, int)
- execute(String, int[])
- execute(String, String[])
- executeUpdate(String)
- executeUpdate(String, int)
- executeUpdate(String, int[])
- executeUpdate(String, String[])
- isWrapperFor(Class<?>)
- getMoreResults()
- getMoreResults(int)
- unwrap(Class<T>)

These methods contain logic, but they don't look correct to me. For example all the execute methods delegate to execute(String) and ignore any additional parameters.
