### PR TITLE
[#57] Improve int conversion

### DIFF
--- a/src/main/java/org/neo4j/jdbc/AbstractResultSet.java
+++ b/src/main/java/org/neo4j/jdbc/AbstractResultSet.java
@@ -153,15 +153,11 @@ public abstract class AbstractResultSet implements ResultSet
     @Override
     public int getInt( int i ) throws SQLException
     {
-        Object value = get( i );
-        if ( value == null || !(value instanceof Integer) )
-        {
+        Object rawValue = get(i);
+        if (!(rawValue instanceof Number)) {
             return 0;
         }
-        else
-        {
-            return (Integer) value;
-        }
+        return ((Number) rawValue).intValue();
     }
 
     @Override


### PR DESCRIPTION
Everything non-integer was simply considered equal to 0.
From now on, standard numerical conversion will be performed for
numerical types. 0 is still returned for non-numerical types (for
partial backward compatibility's sake).
